### PR TITLE
Added sed command to remove unneccesary signals dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -51,6 +51,9 @@ build() {
 	# Fix Python2/Python3 conflicts.
 	/usr/share/ros-build-tools/fix-python-scripts.sh -v 3 ${srcdir}/${_dir}
 
+	# Delete signals as a required component from the CMakeLists.txt
+	sed -i 's/REQUIRED COMPONENTS signals/REQUIRED COMPONENTS/g' ${srcdir}/${_dir}/CMakeLists.txt
+
 	# Build the project.
 	cmake ${srcdir}/${_dir} \
 		-DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
I added a sed command that removes the signals dependency in the CMakeList.txt. This is already in the offical ROS repository but not in the newest release so this is just a fix for now that can be removed once the latest release is out. Without this code, the package doesn't build. 